### PR TITLE
Change TargetPosition calculation in %

### DIFF
--- a/src/server/position-management.ts
+++ b/src/server/position-management.ts
@@ -43,7 +43,7 @@ export class PositionManager {
         var newShort = this._shortEwma.addNewValue(fv.price);
         var newLong = this._longEwma.addNewValue(fv.price);
 
-        var newTargetPosition = (newShort - newLong) / 2.0;
+        var newTargetPosition = ((newShort * 100/ newLong) -100) * 5;
 
         if (newTargetPosition > 1) newTargetPosition = 1;
         if (newTargetPosition < -1) newTargetPosition = -1;


### PR DESCRIPTION
In order to be ready for trading alts with Tribeca, we need to change the formula to calculate the target position in percentage rather than in raw value.

The * 5 is an arbitrary value of the sensibility (reflecting the sensibility we have now on tribeca)
In this case it means that a 0.2% difference between Ewma 100 and ewma 200 will put the TargetPosition of 1 meaning all funds minus pdiv should be in crypto.
A -0.2% difference will show a target position of -1 meaning all funds minus pdiv should be in fiat!

Related to https://github.com/ctubio/tribeca/issues/31
PS: I didn't try the code but it should work! I mean it's only one line haha