### PR TITLE
BIG MATH ERROR -> NEEDS TO BE MERGED ASAP! (easy ewma mod explained)

### DIFF
--- a/src/server/position-management.ts
+++ b/src/server/position-management.ts
@@ -78,8 +78,7 @@ export class PositionManager {
         this.newLong = this._longEwma.addNewValue(fv.price);
 
         const minTick = this._details.minTickIncrement;
-        const factor = 1/minTick;
-        let newTargetPosition = ((this.newShort * factor/ this.newLong) - factor) * 5;
+        let newTargetPosition = ((this.newShort * 100/ this.newLong) - 100) * 5;
 
         if (newTargetPosition > 1) newTargetPosition = 1;
         if (newTargetPosition < -1) newTargetPosition = -1;


### PR DESCRIPTION
I just bumped into this one after I've seen EWMA basic acting super weird on ETC!!!


Factor is just the worst idea ever!!!

Here you're looking to have a % easily comparable for all markets. Not something depending on MinTICK that gives stupid results if you're not trading with 2 decimal.

IE:
ECT -> Min TICK 0.001 -> Factor = 1/Mintick = 1000
So let's say EWMA short = 10.1 and EWMA long = 10 (so a 1% increase).

Instead of getting 1% the good result you get:
(10.1 * 1000 / 10) - 1000 = 10..... 10 times bigger.


And the issue was multiplied by 10 for each mintick you went down !!!